### PR TITLE
Sorting change from run date > submit date

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
           disp_error(errorMsg);
           return;
         }
-        queue.sort((a, b) => ((a.date != b.date) ? ((a.date > b.date) - 0.5) : 0));
+        queue.sort((a, b) => ((a.submitted != b.submitted) ? ((a.submitted > b.submitted) - 0.5) : 0));
         working_queue = queue;
         try {
           var varObj = json_from_src(`games/${gameID}/variables`, xhr);


### PR DESCRIPTION
I noticed an inherent issue with sorting the queue by run date, and that's the simple fact that the user can input whatever date they want for the run.
Theoretically if someone wanted to "skip" the queue, all they would have to do is submit with an earlier date, placing them wherever they want in the queue instead of the bottom.
The commit only changes the sorting and not the displayed date, this is more of a PSA than a proper pull request.