### PR TITLE
Changed input to form; added hash urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
       }
 
       async function get_queue() {
-        let abbr = document.getElementById("abbreviation").value;
+        let abbr = window.location.hash.substring(1);
         try {
           var gameObj = await json_from_src_await(`games/${abbr}`);
         }
@@ -582,6 +582,22 @@
           return "?";
         }
       }
+      
+      function user_get_queue(){
+        window.location.hash = document.getElementById("abbreviation").value;
+      }
+      
+      window.onhashchange = () => {
+        document.getElementById("abbreviation").value = window.location.hash.substring(1);
+        get_queue();
+      }
+      
+      window.onload = (event) => {
+        if(window.location.hash.length > 0){
+          document.getElementById("abbreviation").value = window.location.hash.substring(1);
+          get_queue();
+        }
+      }
     </script>
   </head>
   <body style="font-family:sans-serif" class="light">
@@ -593,10 +609,10 @@
     </div>
     <div id="prompt" style="text-align:center">
       <p>Enter the abbreviation for the game you wish to fetch the queue of:</p>
-      <p>
+      <form action="javascript:user_get_queue()">
         <input type="text" name="abbreviation" id="abbreviation" class="light" size="30"/>
-        <button onclick="get_queue()" class="light">Fetch Queue</button>
-      </p>
+        <input type="submit" class="light" value="Fetch Queue"/>
+      </form>
     </div>
     <div id="pre-table" style="text-align:center">
       <p id="category-error"></p>


### PR DESCRIPTION
- Changes the input to a form so you can press enter to submit instead of having to move your mouse and click a button.
- Added hash urls, for example fetching "smb1" would set the url to https://randomidiot13.github.io/queueclient-web/#smb1 which would directly load the queue for smb1.